### PR TITLE
fix: progress bar blocking content links

### DIFF
--- a/layouts/partials/article/progress.html
+++ b/layouts/partials/article/progress.html
@@ -1,4 +1,4 @@
-<aside id="progressBar" class="aside-container" style="width:30px;margin-left:0;">
+<aside id="progressBar" class="aside-container">
     <div class="aside-align">
       <div>
         <div class="overlap-container">

--- a/layouts/partials/article/progress.html
+++ b/layouts/partials/article/progress.html
@@ -1,11 +1,11 @@
-<aside id="progressBar" class="aside-container">
+<aside id="progressBar" class="aside-container" style="width:30px;margin-left:0;">
     <div class="aside-align">
       <div>
         <div class="overlap-container">
         </div>
       </div>
     </div>
-    
+
     <div class="progress-container" tabIndex={-1}>
         <div class="track-line" aria-hidden="true">
             <div id="progressIndicator" class="progress-line"></div>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -6,11 +6,11 @@
 
     {{ partial "article/progress" . }}
 
-    <article  id="articleContent" class="post-content">
+    <article  id="articleContent" class="post-content" style="position:relative;">
         {{ .Content }}
     </article>
 
-    
+
     {{ partial "article/next.html" . }}
 </section>
 


### PR DESCRIPTION
Confirmed #15; the progress bar overlaps the content, making links unclickable. 

<img width="1331" alt="progress bar" src="https://user-images.githubusercontent.com/6248565/73886238-cfc96800-482e-11ea-99aa-d7f1ec6a0f36.png">

z-index futzing disappears the progress bar in my attempts. Here's one solution: limiting the width of the progress bar. 

<img width="1118" alt="progress bar fix" src="https://user-images.githubusercontent.com/6248565/73886299-eec7fa00-482e-11ea-9f5d-245e82882fa5.png">

My fix works and is ugly and should be done some other way, I imagine. 