### PR TITLE
Fix incorrect date format

### DIFF
--- a/layouts/partials/article/next.html
+++ b/layouts/partials/article/next.html
@@ -47,7 +47,7 @@ of the whole section and append them to our $next slice. */}}
                                 {{ $article.Params.excerpt }}
                             </p>
                             <div class="article-metadata">
-                                {{ $article.Date | dateFormat "January 1, 2006" }} · {{ $article.ReadingTime }} min read
+                                {{ $article.Date | dateFormat "January 2, 2006" }} · {{ $article.ReadingTime }} min read
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This makes the partial to in fact use the day of the month instead of the numeric representation of the month.

More info: https://gohugo.io/functions/format/