### PR TITLE
Fix: image width

### DIFF
--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -209,6 +209,7 @@ img.Image__Zoom ~ div {
 }
 
 img{
+  width: 100%;
   -webkit-animation-name: image-load-in;
           animation-name: image-load-in;
   -webkit-animation-duration: 0.8s;

--- a/assets/scss/global.scss
+++ b/assets/scss/global.scss
@@ -209,7 +209,7 @@ img.Image__Zoom ~ div {
 }
 
 img{
-  width: 100%;
+  max-width: 100%;
   -webkit-animation-name: image-load-in;
           animation-name: image-load-in;
   -webkit-animation-duration: 0.8s;


### PR DESCRIPTION
Ensuring all images fit inside the bounds of the theme.
This somewhat fixes #28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/forestryio/hugo-theme-novela/50)
<!-- Reviewable:end -->
