### PR TITLE
Fixed several image processing issues and added <base> tag to <head>

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A port of [Narative](https://www.narative.co/)'s Gatsby theme [Novela](https://w
 
 ![](https://raw.githubusercontent.com/forestryio/hugo-theme-novela/master/images/tn.png)
 
-The easiest way to get started is to import this theme in Forestry CMS in a single click:
+The easiest way to get started is to [import this theme in Forestry CMS](https://app.forestry.io/quick-start?repo=forestryio/novela-hugo-starter&engine=hugo&version=0.75.1) in a single click
 
 <a href="https://app.forestry.io/quick-start?repo=forestryio/novela-hugo-starter&engine=hugo&version=0.75.1">
     <img alt="Import this project into Forestry" src="https://assets.forestry.io/import-to-forestryK.svg" />
@@ -14,9 +14,9 @@ The easiest way to get started is to import this theme in Forestry CMS in a sing
 
 ## Install from the command line
 
-This theme uses [Hugo modules](https://gohugo.io/hugo-modules/use-modules/).
+If you don't want to use the [starter](htps://github.com/forestryio/novela-hugo-starter), you can start from scratch and just install this theme from the command line.
 
-Create a new Hugo site and initialize your project as a module:
+Create a new Hugo site and initialize your project as a [Hugo module](https://gohugo.io/hugo-modules/use-modules/):
 
 ```
 hugo new site my-awesome-blog
@@ -24,8 +24,7 @@ cd my-awesome-blog
 hugo mod init
 ```
 
-Edit your `config.toml` to add theme settings:
-
+Edit your `config.toml` to add the theme settings:
 
 ```toml
 # Novela settings
@@ -52,6 +51,8 @@ Create your first draft post and preview it locally:
 hugo new post/my-first-post.md
 hugo server -D
 ```
+
+You're good to go!
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ paginate = 6
 [social]
 twitter= "https://twitter.com/forestryio"
 github= "https://github.com/forestryio/novela-hugo-starter"
-linkedin= "https://www.linkedin.com/company/forestry.io"instagram = "#"
+linkedin= "https://www.linkedin.com/company/forestry.io"
 instagram = "#"
 dribbble = "#"
 youtube = "#"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,52 @@ A port of [Narative](https://www.narative.co/)'s Gatsby theme [Novela](https://w
 
 ![](https://raw.githubusercontent.com/forestryio/hugo-theme-novela/master/images/tn.png)
 
-<a href="https://app.forestry.io/quick-start?repo=forestryio/novela-hugo-starter&engine=hugo&version=0.62.2">
+The easiest way to get started is to import this theme in Forestry CMS in a single click:
+
+<a href="https://app.forestry.io/quick-start?repo=forestryio/novela-hugo-starter&engine=hugo&version=0.75.1">
     <img alt="Import this project into Forestry" src="https://assets.forestry.io/import-to-forestryK.svg" />
 </a>
+
+## Install from the command line
+
+This theme uses [Hugo modules](https://gohugo.io/hugo-modules/use-modules/).
+
+Create a new Hugo site and initialize your project as a module:
+
+```
+hugo new site my-awesome-blog
+cd my-awesome-blog
+hugo mod init
+```
+
+Edit your `config.toml` to add theme settings:
+
+
+```toml
+# Novela settings
+theme = "github.com/forestryio/hugo-theme-novela"
+
+paginate = 6
+
+[social]
+twitter= "https://twitter.com/forestryio"
+github= "https://github.com/forestryio/novela-hugo-starter"
+linkedin= "https://www.linkedin.com/company/forestry.io"instagram = "#"
+instagram = "#"
+dribbble = "#"
+youtube = "#"
+
+[taxonomies]
+author = "authors"
+
+```
+
+Create your first draft post and preview it locally:
+
+```
+hugo new post/my-first-post.md
+hugo server -D
+```
 
 ## Customization
 

--- a/layouts/partials/article/hero.html
+++ b/layouts/partials/article/hero.html
@@ -12,7 +12,7 @@
         </header>
         {{ with .Page.Params.hero }}
         <div class="article-hero-image" id="ArticleImage__Hero">
-            <img src="{{ . }}">
+            <img src="{{ $.Site.BaseURL }}{{ . }}">
         </div>
         {{ end }}
     </div>

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,4 +1,5 @@
 <head>
+    <base href="{{ .Site.BaseURL }}">
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <Section class="section">
   <div class="nav-container">
-    <a class="logo-link" href="/">
+    <a class="logo-link" href="{{ .Site.BaseURL }}">
       {{ partial "icons/ui/logo.html" . }}
       <span class="header-hidden">Navigate back to the homepage</span>
     </a>


### PR DESCRIPTION
The viewport height setting is to resolve an issue where hero images over 1070px were loading over the text, and the <base> tag allows canonical links to accomodate the url subdirectory when built in github pages. Example: https://ryanjbartley.github.io/gphugo