### PR TITLE
Limit list elements to direct children only

### DIFF
--- a/assets/scss/lists.scss
+++ b/assets/scss/lists.scss
@@ -63,7 +63,7 @@ ul li > *{
     display: inline;
 }
 
-ul li::before{
+ul > li::before{
     width: 3rem;
     display: inline-block;
     position: absolute;
@@ -79,7 +79,7 @@ ul li::before{
 
 /*TABLET*/
 @media screen and (max-width: 735px){
-    ul li::before{
+    ul > li::before{
         left: 0;
     }
 }
@@ -148,7 +148,7 @@ ol li > *{
     display: inline;
 }
 
-ol li::before {
+ol > li::before {
     width: 3rem;
     display: inline-block;
     position: absolute;
@@ -163,7 +163,7 @@ ol li::before {
 }
 
 @media screen and (max-width: 735px){
-    ol li::before{
+    ol > li::before{
         left: 0;
     }
 }


### PR DESCRIPTION
Without this fix, nested lists are broken, especially mixed
ordered/unordered nested lists. This is because rulesets from both
apply, causing double display of styling on a given element.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`

Before:

![Screenshot from 2020-12-26 19-47-22](https://user-images.githubusercontent.com/914030/103161681-8883f700-47b3-11eb-847b-743d4e8f96f4.png)

After:
![Screenshot from 2020-12-26 19-49-25](https://user-images.githubusercontent.com/914030/103161684-920d5f00-47b3-11eb-8197-2ee54a00ddff.png)

-----

Note: You might also consider applying a rule to indent nested lists, but that is outside the scope of this PR. 