### PR TITLE
Tweak base template and allow for extra stylesheets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ Override `/themes/novela/layouts/partials/icons/ui/logo.html` with your own file
 
 Novela supports light and dark mode. To have your logo respond in kind, add `class="change-fill"` to the svg path(s).
 
+### Stylesheets
+
+Override `/themes/novela/layouts/partials/head/extra_styles.html` with your own files at `/layouts/partials/head/extra_styles.html`; include a relative link to your local stylesheet.
+
+For example, here is how to include a CSS file located at `/assets/css/main.css`:
+
+#### **`/layouts/partials/head/extra_styles.html`**
+
+```html
+{{ $extraCss := resources.Get "css/main.css" }}
+<link rel="stylesheet" href="{{$extraCss.RelPermalink}}">
+```
+
 ### Socials
 
 In order for the Socials to be surfaced in Forestry, you should copy the theme's `config/_default/social.yaml` to your project.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,6 +3,7 @@
 
 <head>
     {{ partial "head/head.html" . }}
+    {{ partial "head/extra_styles.html" . }}
 </head>
 
 <body class="line-numbers">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
 
-{{ partial "head/head.html" . }}
+<head>
+    {{ partial "head/head.html" . }}
+</head>
 
 <body class="line-numbers">
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 {{ partial "head/head.html" . }}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,15 +1,13 @@
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="/images/favicon.svg">
-    {{ $style := resources.Get "scss/global.scss" | toCSS | minify | fingerprint }}
-    <link rel="stylesheet" href="{{ $style.RelPermalink }}">
-    {{ $prism := resources.Get "css/prism.css" }}
-    <link rel="stylesheet" href="{{ $prism.RelPermalink }}" />
-    <link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
-    {{ partial "seo/print.html" . }}
-    {{ with .Params.forestry_instant_preview_id }}
-      {{- safeHTML (printf "<meta property='forestry_instant_preview_id' content='%s'>" .) -}}
-    {{ end -}}
-</head>
+<meta charset="utf-8">
+<meta http-equiv="x-ua-compatible" content="ie=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<link rel="icon" href="/images/favicon.svg">
+{{ $style := resources.Get "scss/global.scss" | toCSS | minify | fingerprint }}
+<link rel="stylesheet" href="{{ $style.RelPermalink }}">
+{{ $prism := resources.Get "css/prism.css" }}
+<link rel="stylesheet" href="{{ $prism.RelPermalink }}" />
+<link href="https://fonts.googleapis.com/css?family=Merriweather&display=swap" rel="stylesheet">
+{{ partial "seo/print.html" . }}
+{{ with .Params.forestry_instant_preview_id }}
+  {{- safeHTML (printf "<meta property='forestry_instant_preview_id' content='%s'>" .) -}}
+{{ end -}}


### PR DESCRIPTION
### Suggested Changes

**Add document type to the base template.**

- Add `<!DOCTYPE html>` to `_default/baseof.html`.

**Allow for site-specific stylesheets to be more easily added.**

- Move `<head>` from `partial/head/head.html` to `_default/baseof.html`.
- Create and include a new, empty template, `partials/head/extra_styles.html`.
- Add section to README about how to override `extra_styles.html`.

_This is just my ideal implementation._

### Why make the changes?

- Create HTML which is slightly more valid.
- Make it easier to override default styling without needing to create a custom remote.